### PR TITLE
Correct rotation axis for weapon interaction

### DIFF
--- a/src/components/model-viewer/ModelViewer.vue
+++ b/src/components/model-viewer/ModelViewer.vue
@@ -150,8 +150,8 @@ onMounted(async () => {
   }
 
   function rotateObject(deltaX: number, deltaY: number) {
-    object.rotation.z += deltaX / 100
-    object.rotation.y += deltaY / 100
+    object.rotation.y += deltaX / 100
+    object.rotation.z += deltaY / 100
   }
 
   // Mouse click or first touch


### PR DESCRIPTION
## Changes

When I was previously changing the `ModelViewer` axis, the weapon grid wasn't responsive. 

Now that it's responsive (as per d1c60fd), the interaction axis was wonky and inverted so I fixed it.