### PR TITLE
Added BattleBits API Integration to display Population stats

### DIFF
--- a/locales/en.yml
+++ b/locales/en.yml
@@ -31,10 +31,12 @@ openSource: Open source
 pageNotFound: Page not found
 pageWorkingInProgress: This page is a work in progress pending more data collection
 playerStats: Player stats
+playersOnline: 'players online'
 prestige: Prestige
 rank: Rank
 requestAccess: Request access
 returnToCombatArea: Return to the combat area
+serverCount: 'servers'
 siteCreatedBy: 'Site created by '
 siteNotAffiliatedWith: This site is not affiliated with OkiStudio
 starts: starts {startTime}

--- a/src/components/navigation/header/Header.vue
+++ b/src/components/navigation/header/Header.vue
@@ -4,7 +4,10 @@ import { faServer, faUserFriends } from '@fortawesome/free-solid-svg-icons'
 import type { PopulationStats } from '~/lib/BattleBitApiWrapper'
 import { getCurrentPopulationStats } from '~/lib/BattleBitApiWrapper'
 
-const populationStats = $ref<PopulationStats>({})
+const populationStats = $ref<PopulationStats>({
+  playerCount: -1,
+  serverCount: -1
+})
 const refreshPopulationStats = async () => {
   try {
     const stats = await getCurrentPopulationStats()
@@ -56,20 +59,25 @@ const { t } = useI18n()
         </Button>
       </div>
       <div
-        v-if="populationStats.playerCount > 0"
         class="col-span-2 flex bg-gray-800 py-1 px-4 text-center sm:col-span-1 sm:col-start-2 sm:row-start-2 sm:justify-end lg:px-0"
       >
         <div class="flex-grow sm:flex-grow-0 sm:px-4">
           <div class="sm:inline-block">
             <FontAwesomeIcon :icon="faUserFriends" />
-            <span class="px-1 text-xl font-medium">{{ populationStats.playerCount }}</span>
+            <span v-if="populationStats.playerCount >= 0" class="px-1 text-xl font-medium">{{
+              populationStats.playerCount
+            }}</span>
+            <span v-else class="px-1 text-xl font-medium">...</span>
           </div>
           <span class="col-start-2 hidden px-1 text-gray-400 sm:inline-block">{{ t('playersOnline') }}</span>
         </div>
         <div class="grid flex-grow px-4 sm:inline-block sm:flex-grow-0 sm:px-0">
           <div class="sm:inline-block">
             <FontAwesomeIcon :icon="faServer" />
-            <span class="px-1 text-xl font-medium">{{ populationStats.serverCount }}</span>
+            <span v-if="populationStats.serverCount >= 0" class="px-1 text-xl font-medium">{{
+              populationStats.serverCount
+            }}</span>
+            <span v-else class="px-1 text-xl font-medium">...</span>
           </div>
           <span class="col-start-2 hidden px-1 text-gray-400 sm:inline-block">{{ t('serverCount') }}</span>
         </div>

--- a/src/components/navigation/header/Header.vue
+++ b/src/components/navigation/header/Header.vue
@@ -23,7 +23,7 @@ const { t } = useI18n()
 </script>
 
 <template>
-  <nav class="flex auto-cols-min items-center justify-between bg-gray-800 px-2 py-2 text-white sm:px-4">
+  <nav class="flex flex-shrink-0 auto-cols-min items-center justify-between bg-gray-800 px-2 py-2 text-white sm:px-4">
     <div class="grid-auto-cols grid-cols-2-[repeat(2,auto)] grid flex-grow grid-rows-2">
       <router-link
         to="/"
@@ -57,19 +57,19 @@ const { t } = useI18n()
       </div>
       <div
         v-if="populationStats.playerCount > 0"
-        class="col-span-2 flex basis-full flex-wrap justify-center self-center bg-gray-800 px-4 py-2 text-center sm:col-span-1 sm:col-start-2 sm:row-start-2 sm:justify-end sm:text-left lg:px-0"
+        class="col-span-2 flex bg-gray-800 py-1 px-4 text-center sm:col-span-1 sm:col-start-2 sm:row-start-2 sm:justify-end lg:px-0"
       >
-        <div class="grid flex-grow px-4 sm:inline-block sm:flex-grow-0 sm:px-4">
-          <div class="col-start-1 sm:inline-block">
+        <div class="flex-grow sm:flex-grow-0 sm:px-4">
+          <div class="sm:inline-block">
             <FontAwesomeIcon :icon="faUserFriends" />
-            <span class="px-1 text-xl font-medium text-yellow-50">{{ populationStats.playerCount }}</span>
+            <span class="px-1 text-xl font-medium">{{ populationStats.playerCount }}</span>
           </div>
           <span class="col-start-2 hidden px-1 text-gray-400 sm:inline-block">{{ t('playersOnline') }}</span>
         </div>
         <div class="grid flex-grow px-4 sm:inline-block sm:flex-grow-0 sm:px-0">
-          <div class="col-start-1 sm:inline-block">
+          <div class="sm:inline-block">
             <FontAwesomeIcon :icon="faServer" />
-            <span class="px-1 text-xl font-medium text-yellow-50">{{ populationStats.serverCount }}</span>
+            <span class="px-1 text-xl font-medium">{{ populationStats.serverCount }}</span>
           </div>
           <span class="col-start-2 hidden px-1 text-gray-400 sm:inline-block">{{ t('serverCount') }}</span>
         </div>

--- a/src/components/navigation/header/Header.vue
+++ b/src/components/navigation/header/Header.vue
@@ -1,39 +1,79 @@
 <script setup lang="ts">
 import { faSteamSymbol } from '@fortawesome/free-brands-svg-icons'
+import { faServer, faUserFriends } from '@fortawesome/free-solid-svg-icons'
+import type { PopulationStats } from '~/lib/BattleBitApiWrapper'
+import { getCurrentPopulationStats } from '~/lib/BattleBitApiWrapper'
+
+const populationStats = $ref<PopulationStats>({})
+const refreshPopulationStats = async () => {
+  try {
+    const stats = await getCurrentPopulationStats()
+    populationStats = stats
+  } catch (error) {
+    console.error(error)
+  }
+}
+
+onMounted(async () => {
+  await refreshPopulationStats()
+  setInterval(refreshPopulationStats, 5000)
+})
 
 const { t } = useI18n()
 </script>
 
 <template>
-  <nav class="flex items-center justify-between px-2 py-2 text-white bg-gray-800 sm:px-4">
-    <router-link
-      to="/"
-      :title="t('home')"
-      class="items-center hidden text-xl font-extrabold tracking-wide uppercase text-yellow-50 sm:flex"
-    >
-      <img src="/logo-white.png" class="mr-2 h-[20px]" />
-      {{ t('battleBitStats') }}
-    </router-link>
-
-    <div class="flex items-center flex-1 space-x-8 sm:flex-initial">
-      <div class="flex justify-between w-full sm:w-auto sm:max-w-none sm:space-x-4 md:space-x-8">
-        <NavItem to="/" :label="t('home')" />
-
-        <NavItem to="/maps/isle" :exact-path="false" :label="t('maps')" />
-
-        <NavItem to="/weapons/assault/M4A1" :label="t('weapons')" />
-
-        <NavItem to="/stats/player/titan" :label="t('playerStats')" class="hidden md:block" />
-        <NavItem to="/stats/player/titan" :label="t('stats')" class="md:hidden" />
-      </div>
-
-      <Button
-        to="https://store.steampowered.com/app/671860/BattleBit_Remastered/"
-        :prefix-icon="faSteamSymbol"
-        class="hidden lg:block"
+  <nav class="flex auto-cols-min items-center justify-between bg-gray-800 px-2 py-2 text-white sm:px-4">
+    <div class="grid-auto-cols grid-cols-2-[repeat(2,auto)] grid flex-grow grid-rows-2">
+      <router-link
+        to="/"
+        :title="t('home')"
+        class="hidden flex-row items-center text-xl font-extrabold uppercase tracking-wide text-yellow-50 sm:row-span-2 sm:flex"
       >
-        {{ t('requestAccess') }}
-      </Button>
+        <img src="/logo-white.png" class="mr-2 h-[20px]" />
+        {{ t('battleBitStats') }}
+      </router-link>
+      <div class="col-span-2 flex w-full flex-1 items-center space-x-8 sm:col-span-1 sm:flex-initial">
+        <div
+          class="flex w-full flex-grow justify-between sm:w-auto sm:max-w-none sm:justify-end sm:space-x-4 md:space-x-8"
+        >
+          <NavItem to="/" :label="t('home')" />
+
+          <NavItem to="/maps/isle" :exact-path="false" :label="t('maps')" />
+
+          <NavItem to="/weapons/assault/M4A1" :label="t('weapons')" />
+
+          <NavItem to="/stats/player/titan" :label="t('playerStats')" class="hidden md:block" />
+          <NavItem to="/stats/player/titan" :label="t('stats')" class="md:hidden" />
+        </div>
+
+        <Button
+          to="https://store.steampowered.com/app/671860/BattleBit_Remastered/"
+          :prefix-icon="faSteamSymbol"
+          class="hidden lg:block"
+        >
+          {{ t('requestAccess') }}
+        </Button>
+      </div>
+      <div
+        v-if="populationStats.playerCount > 0"
+        class="col-span-2 flex basis-full flex-wrap justify-center self-center bg-gray-800 px-4 py-2 text-center sm:col-span-1 sm:col-start-2 sm:row-start-2 sm:justify-end sm:text-left lg:px-0"
+      >
+        <div class="grid flex-grow px-4 sm:inline-block sm:flex-grow-0 sm:px-4">
+          <div class="col-start-1 sm:inline-block">
+            <FontAwesomeIcon :icon="faUserFriends" />
+            <span class="px-1 text-xl font-medium text-yellow-50">{{ populationStats.playerCount }}</span>
+          </div>
+          <span class="col-start-2 hidden px-1 text-gray-400 sm:inline-block">{{ t('playersOnline') }}</span>
+        </div>
+        <div class="grid flex-grow px-4 sm:inline-block sm:flex-grow-0 sm:px-0">
+          <div class="col-start-1 sm:inline-block">
+            <FontAwesomeIcon :icon="faServer" />
+            <span class="px-1 text-xl font-medium text-yellow-50">{{ populationStats.serverCount }}</span>
+          </div>
+          <span class="col-start-2 hidden px-1 text-gray-400 sm:inline-block">{{ t('serverCount') }}</span>
+        </div>
+      </div>
     </div>
   </nav>
 </template>

--- a/src/lib/BattleBitApiWrapper.ts
+++ b/src/lib/BattleBitApiWrapper.ts
@@ -1,0 +1,74 @@
+const API_URL = 'https://publicapi.battlebit.cloud/Servers/GetServerList'
+
+enum GameMode {
+  TDM = 'TDM',
+  CONQ = 'CONQ',
+  VoxelFortify = 'VoxelFortify',
+  FRONTLINE = 'FRONTLINE',
+  DOMI = 'DOMI',
+  CaptureTheFlag = 'CaptureTheFlag',
+  INFCONQ = 'INFCONQ',
+  RUSH = 'RUSH',
+  VoxelTrench = 'VoxelTrench',
+  FFA = 'FFA',
+  ELI = 'ELI'
+}
+
+enum MapSize {
+  Tiny = 'Tiny',
+  Big = 'Big',
+  Ultra = 'Ultra',
+  Medium = 'Medium',
+  Small = 'Small'
+}
+
+enum DayNight {
+  Day = 'Day',
+  Night = 'Night'
+}
+
+enum Anticheat {
+  None = 'None',
+  EAC = 'EAC'
+}
+
+export interface Server {
+  Name: string
+  Map: string
+  MapSize: MapSize
+  Gamemode: GameMode
+  Players: number
+  QueuePlayers: number
+  MaxPlayers: number
+  Hz: number
+  DayNight: DayNight
+  IsOfficial: boolean
+  HasPassword: boolean
+  Anticheat: Anticheat
+  Build: string
+}
+
+export const getServerList = async (): Promise<Server[]> => {
+  const response = await fetch(API_URL)
+  const data = await response.json()
+
+  return data
+}
+
+export interface PopulationStats {
+  playerCount: number
+  queueCount: number
+  serverCount: number
+}
+
+export const getCurrentPopulationStats = async (): Promise<PopulationStats> => {
+  const servers = await getServerList()
+  const playerCount = servers.reduce((acc, server) => acc + server.Players, 0)
+  const queueCount = servers.reduce((acc, server) => acc + server.QueuePlayers, 0)
+
+  return {
+    playerCount,
+    queueCount,
+    serverCount: servers.length
+  }
+}

--- a/src/lib/map-config.ts
+++ b/src/lib/map-config.ts
@@ -14,7 +14,8 @@ export const maps: Record<string, MapConfig> = {
   basra: {
     bgColor: '#7292a6',
     name: 'Basra',
-    description: 'An archipelago with a grounded container ship in the map's center. The northern island is a military base, while the southern island has a tourist resort and public airport'
+    description:
+      "An archipelago with a grounded container ship in the map's center. The northern island is a military base, while the southern island has a tourist resort and public airport"
   },
   valley: {
     bgColor: '#715d3a',

--- a/src/pages/weapons/[classSlug]/[weaponSlug].vue
+++ b/src/pages/weapons/[classSlug]/[weaponSlug].vue
@@ -20,7 +20,7 @@ const objectModel = $computed(() => ({
 </script>
 
 <template>
-  <div class="arsenal h-[calc(100vh-90px)] overflow-hidden">
+  <div class="arsenal h-[calc(100vh-129px)] overflow-hidden">
     <div class="arsenal-grid relative flex h-full w-full flex-col md:flex-row">
       <div
         class="scrollbar-vertical relative z-20 order-2 h-full w-full overflow-y-auto px-4 pb-8 md:order-1 md:max-w-[320px]"


### PR DESCRIPTION
- queries the battlebit api every 5 seconds to get up-to-date population stats
  -  api is still quite limited, but it'd be enough to build a server browser or do some pie charts from the data eventually.
  - as far as I know, this is the only endpoint that is currently available: https://publicapi.battlebit.cloud/Servers/GetServerList
- feel free to reject if it's not a feature you're looking for


![image](https://github.com/alexcroox/battlebit-stats/assets/45246069/cdc6cab1-f330-4eab-be0b-add56297fbe9)
![image](https://github.com/alexcroox/battlebit-stats/assets/45246069/45cb2b6d-0393-45a5-a084-3dda0c81d7b6)

if it can't load the data for some reason, it'll display a placeholder
![image](https://github.com/alexcroox/battlebit-stats/assets/45246069/53b2e326-d324-49c4-b427-e452c1fe7866)

